### PR TITLE
Fixes and maintenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install system dependencies
+      run: >
+        sudo apt-get update;
+        sudo apt-get install -yq
+        python3-msgpack
+        python3-numpy
+
+    - name: Test
+      run: python3 test.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Experimental MMTF I/O Python Library
+# MMTF I/O Python Library
 
 **simplemmtf** is a lightweight [MMTF](http://mmtf.rcsb.org/) encoding and decoding module written in Python. It was originally developed for PyMOL 1.8.4 to prototype MMTF load support.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This implementation is similar (but unrelated) to [mmtf-python](https://github.c
 
 ## Dependencies
 
+* Python 3.6+
 * [msgpack-python](https://github.com/msgpack/msgpack-python) or [u-msgpack-python](https://github.com/vsergeev/u-msgpack-python)
 * numpy (optional)
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,28 @@
+{% set data = load_setup_py_data() %}
+
+package:
+  name: simplemmtf-python
+  version: {{ data.get('version') }}
+
+about:
+  license: BSD-3-Clause
+  license_family: BSD
+  summary: MMTF I/O Python Library
+
+source:
+  path: ../
+
+requirements:
+  host:
+    - python
+  run:
+    - python >=3.6
+    - msgpack-python
+
+build:
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  noarch: python
+
+test:
+  imports:
+    - simplemmtf

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="simplemmtf",
     description='MMTF I/O library',
-    version='0.2',
+    version='1.0',
     py_modules=[
         "simplemmtf",
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name="simplemmtf",

--- a/simplemmtf.py
+++ b/simplemmtf.py
@@ -73,10 +73,6 @@ Serialize atom table to MMTF:
 
 '''
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import sys
 import itertools
@@ -91,28 +87,15 @@ except ImportError:
     _KWARGS_UNPACK = {}
     _KWARGS_PACK = {}
 
-if sys.version_info[0] < 3:
-    from urllib import urlopen
-    izip = itertools.izip
-    izip_longest = itertools.izip_longest
-    _next_method_name = 'next'
-    chr = unichr
-else:
-    # python3
-    from urllib.request import urlopen
-    izip = zip
-    izip_longest = itertools.zip_longest
-    buffer = lambda s, i=0: memoryview(s)[i:]
-    xrange = range
-    _next_method_name = '__next__'
-    unicode = str
+from urllib.request import urlopen
+_next_method_name = '__next__'
 
 
 def mmtfstr(s):
     '''Cast `s` to MMTF compatible string'''
     if isinstance(s, bytes):
         return s.decode('ascii')
-    return unicode(s)
+    return str(s)
 
 
 class _apiproxy:
@@ -350,7 +333,7 @@ class StringsBuffer:
         e = self.encoding
         return [
             bytes(in_bytes[i:i + n]).rstrip(b'\0').decode(e)
-            for i in xrange(0, len(in_bytes), n)
+            for i in range(0, len(in_bytes), n)
         ]
 
     def encode(self, strings):
@@ -494,7 +477,7 @@ def decode_array(value):
     params = struct.unpack(MMTF_ENDIAN + fmt, value[8:12])
     strategy = strategies[codec](*params)
 
-    value = buffer(value, 12)
+    value = memoryview(value)[12:]
     for handler in strategy:
         value = handler.decode(value)
 
@@ -780,8 +763,8 @@ class MmtfDict:
         missing columns.
         '''
         if defaults is None:
-            return izip_longest(*[self.get_iter(k) for k in keys])
-        return izip(*[
+            return itertools.zip_longest(*[self.get_iter(k) for k in keys])
+        return zip(*[
             self.get_iter(k, itertools.repeat(d))
             for (k, d) in zip(keys, defaults)
         ])
@@ -913,7 +896,7 @@ def _atoms_iter(data, bonds=None, _just_groups=False):
                     continue
 
                 if bonds is not None:
-                    group_bond_iter = izip(
+                    group_bond_iter = zip(
                         group[u'bondAtomList'][0::2],
                         group[u'bondAtomList'][1::2],
                         group[u'bondOrderList'], )

--- a/simplemmtf.py
+++ b/simplemmtf.py
@@ -84,7 +84,7 @@ import struct
 
 try:
     import msgpack
-    _KWARGS_UNPACK = {}
+    _KWARGS_UNPACK = {'encoding': 'utf-8'} if msgpack.version[0] < 1 else {}
     _KWARGS_PACK = {'use_bin_type': True}
 except ImportError:
     import umsgpack as msgpack

--- a/simplemmtf.py
+++ b/simplemmtf.py
@@ -297,7 +297,7 @@ class NumbersBuffer:
 
     def decode(self, in_bytes):
         a = self.array(self.enctype)
-        a.fromstring(in_bytes)
+        a.frombytes(in_bytes)
         if sys.byteorder != 'big':
             a.byteswap()
         return a
@@ -306,7 +306,7 @@ class NumbersBuffer:
         a = self.array(self.enctype, in_ints)
         if sys.byteorder != 'big':
             a.byteswap()
-        return a.tostring()
+        return a.tobytes()
 
 
 @apinumpy
@@ -319,7 +319,7 @@ class NumbersBuffer:
         return numpy.frombuffer(in_bytes, self.enctype).astype(self.dectype)
 
     def encode(self, in_ints):
-        return asarray(in_ints, self.enctype).tostring()
+        return asarray(in_ints, self.enctype).tobytes()
 
 
 @apigeneric
@@ -365,7 +365,7 @@ class StringsBuffer:
     def encode(self, strings):
         s_it = (s.encode(self.encoding) for s in strings)
         bstrings = numpy.fromiter(s_it, self.enctype, len(strings))
-        return bstrings.tostring()
+        return bstrings.tobytes()
 
 
 ########## NUMPY API ############################################

--- a/simplemmtf.py
+++ b/simplemmtf.py
@@ -95,6 +95,7 @@ def mmtfstr(s):
     '''Cast `s` to MMTF compatible string'''
     if isinstance(s, bytes):
         return s.decode('ascii')
+    assert not isinstance(s, bytearray)
     return str(s)
 
 
@@ -487,6 +488,7 @@ def decode_array(value):
 def _get_array_length(value):
     if isinstance(value, bytes):
         return struct.unpack(MMTF_ENDIAN + 'i', value[4:8])[0]
+    assert not isinstance(value, bytearray)
     return len(value)
 
 
@@ -680,7 +682,7 @@ class MmtfDict:
                 self.set(key, value)
             return
 
-        if isinstance(data, bytes):
+        if isinstance(data, (bytes, bytearray)):
             if data[:2] != b'\x1f\x8b':  # gzip magic number
                 self._set_data(msgpack.unpackb(data, **_KWARGS_UNPACK))
                 return

--- a/test.py
+++ b/test.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import os
 import sys
 


### PR DESCRIPTION
- Bump version to v1.0 (tag pending)
- Fix for Python 3.9: `frombytes()` and `tobytes()`
- Add basic CI test with github actions
- Add conda recipe
- distutils -> setuptools ([PEP 632](https://www.python.org/dev/peps/pep-0632/))
- Drop Python 2 support
- Support for msgpack-python < 1.0